### PR TITLE
Add custom JSX pragma

### DIFF
--- a/src/jsx.js
+++ b/src/jsx.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import * as components from './elements'
+
+const elements = {}
+Object.keys(components).forEach(key => {
+  elements[key.toLowerCase()] = components[key]
+})
+
+export const jsx = (type, props, ...children) => {
+  const el = elements[type] || type
+  return React.createElement.apply(undefined, [
+    el,
+    props,
+    ...children
+  ])
+}
+
+export default jsx

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,66 +1,48 @@
+/** @jsx jsx */
+import jsx from '../jsx'
 import React from 'react'
 import theme from '../theme'
-
-import Div from '../elements/Div'
-import Section from '../elements/Section'
-import Article from '../elements/Article'
-import Main from '../elements/Main'
-import Table from '../elements/Table'
-import Tr from '../elements/Tr'
-import Td from '../elements/Td'
-
-import Header from '../elements/Header'
-import Footer from '../elements/Footer'
-import H1 from '../elements/H1'
-import H2 from '../elements/H2'
-import H3 from '../elements/H3'
-import H4 from '../elements/H4'
-import H5 from '../elements/H5'
-import P from '../elements/P'
-import A from '../elements/A'
-import Span from '../elements/Span'
-import Code from '../elements/Code'
 
 import Logo from '../components/Logo'
 import Container from '../components/Container'
 
 function Home() {
   return (
-    <Div>
-      <Header px={4} py={2} borderBottom='1px solid' borderColor='black-20' display='flex' alignItems='center'>
-        <Div maxWidth='6rem'>
-          <A display='block' href='https://tachyons.io'><Logo color='rgba(0,0,0,.7)' /></A>
-        </Div>
-        <A ml='auto' fontSize={0} fontWeight={700} color='black' href='https://github.com/tachyons-css/tachyons-styled-react' title="GitHub">GitHub</A>
-      </Header>
-      <Main>
+    <div>
+      <header px={4} py={2} borderBottom='1px solid' borderColor='black-20' display='flex' alignItems='center'>
+        <div maxWidth='6rem'>
+          <a display='block' href='https://tachyons.io'><Logo color='rgba(0,0,0,.7)' /></a>
+        </div>
+        <a ml='auto' fontSize={0} fontWeight={700} color='black' href='https://github.com/tachyons-css/tachyons-styled-react' title="GitHub">GitHub</a>
+      </header>
+      <main>
         <Container pt={[5,6]} pb={[5,6,7]} px={4}>
-          <H2 fontSize={[3,6,7]} mb={4} mt={0}>Build, design, and style UI at the speed of light</H2>
-          <H3 fontSize={[1,2,3]} lineHeight={1.25} textStyle='caps' color='black-80' mb={5}>
-            <Span display={['block', 'inline']}>Tachyons + </Span> 
-            <Span display={['block', 'inline']}>Styled-system + </Span>
-            <Span display={['block', 'inline']}>Emotion + </Span>
-            <Span display={['block', 'inline']}>Create React App</Span>
-          </H3>
-          <A href='/styles' title="Styles and documentation" 
+          <h2 fontSize={[3,6,7]} mb={4} mt={0}>Build, design, and style UI at the speed of light</h2>
+          <h3 fontSize={[1,2,3]} lineHeight={1.25} textStyle='caps' color='black-80' mb={5}>
+            <span display={['block', 'inline']}>Tachyons + </span>
+            <span display={['block', 'inline']}>Styled-system + </span>
+            <span display={['block', 'inline']}>Emotion + </span>
+            <span display={['block', 'inline']}>Create React App</span>
+          </h3>
+          <a href='/styles' title="Styles and documentation"
              bg='dark-blue' color='white' borderRadius={2} py={3} px={4} fontSize={[1]} fontWeight={700}>
             Styles &amp; Documentation
-          </A>
+          </a>
         </Container>
-    </Main>
-    <Footer borderTop='1px solid' borderColor='black-20' px={4} py={4} display='flex'>
-      <Div>
-        <A color='black' py={1} fontWeight={700} href='https://tachyons.io' title='Tachyons' >Tachyons</A><br/>
-        <A color='black' py={1} fontWeight={700} href='https://tachyons.io/docs' title='Tachyons Docs' >Docs</A><br/>
-        <A color='black' py={1} fontWeight={700} href='https://github.com/tachyons-css/generator' title='Tachyons' >Generator</A><br />
-      </Div>
-      <Div ml='auto' width={144}>
-        <A color='black' py={1} fontWeight={700} href='https://opencollective.com/tachyons' title='Tachyons' >Open Collective</A><br />
-        <A color='black' py={1} fontWeight={700} href='https://github.com/tachyons-css' title='Tachyons' >GitHub</A><br /> 
-        <A color='black' py={1} fontWeight={700} href='https://twitter.com/tachyons_css' title='Tachyons' >Twitter</A>       
-      </Div>
-    </Footer>
-  </Div>
+      </main>
+      <footer borderTop='1px solid' borderColor='black-20' px={4} py={4} display='flex'>
+        <div>
+          <a color='black' py={1} fontWeight={700} href='https://tachyons.io' title='Tachyons' >Tachyons</a><br/>
+          <a color='black' py={1} fontWeight={700} href='https://tachyons.io/docs' title='Tachyons Docs' >Docs</a><br/>
+          <a color='black' py={1} fontWeight={700} href='https://github.com/tachyons-css/generator' title='Tachyons' >Generator</a><br />
+        </div>
+        <div ml='auto' width={144}>
+          <a color='black' py={1} fontWeight={700} href='https://opencollective.com/tachyons' title='Tachyons' >Open Collective</a><br />
+          <a color='black' py={1} fontWeight={700} href='https://github.com/tachyons-css' title='Tachyons' >GitHub</a><br />
+          <a color='black' py={1} fontWeight={700} href='https://twitter.com/tachyons_css' title='Tachyons' >Twitter</a>
+        </div>
+      </footer>
+    </div>
   );
 }
 


### PR DESCRIPTION
This is one way to allow the use of `src/elements` in other files without the need to import. When the `/** @jsx jsx */` custom pragma is added to the top of a module, elements like `<h1>` will be rendered with `src/elements/H1.js` instead of the default HTML element. This avoids adding any values to global scope, and is similar to how MDX renders custom HTML elements