### PR TITLE
fix distDir property of now.json static-build config😅

### DIFF
--- a/now.json
+++ b/now.json
@@ -6,7 +6,7 @@
     {
       "src": "package.json",
       "use": "@now/static-build",
-      "config": { "distDir": "public" }
+      "config": { "distDir": "build" }
     }
   ],
   "routes": [


### PR DESCRIPTION
It was originally set to `build`, but I had mistakenly changed it to `public`. This PR reverts that to the correct value and fixes the blank page currently on https://tachyons-styled-react.now.sh

If everything checks out, don't forget to update the `website` section of your repo information to reflect the latest version of future builds. 

<img width="899" alt="Screen Shot 2019-05-06 at 11 24 32 AM" src="https://user-images.githubusercontent.com/10926503/57239518-b2424600-6ff1-11e9-8ae6-89667cddc4ab.png">
